### PR TITLE
Fix up the company name to follow the 'brand guidelines'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * [RSpec](/RSpec.md)
 * [(S)CSS](/scss.md)
 
-These guidelines provide a summary of coding styles [OnTheBeach](https://www.onthebeach.co.uk). It is not intended to be exhaustive or absolute.  In general, follow the style of the surrounding code while keeping in mind the following:
+These guidelines provide a summary of coding styles [On the Beach](https://www.onthebeach.co.uk). It is not intended to be exhaustive or absolute.  In general, follow the style of the surrounding code while keeping in mind the following:
 
 * Prefer clarity over cleverness
 * Prefer full names over abbreviations
@@ -20,5 +20,5 @@ Pull requests and discussion are welcome.
 
 ### Copyright
 
-Copyright &copy; 2015 OnTheBeach Ltd. See LICENSE.txt for
+Copyright &copy; 2015 On the Beach Ltd. See LICENSE.txt for
 further details.


### PR DESCRIPTION
Previously we used to imply the company was called On The beach.
Everyone loves capital letters right?

However, it's more correct to use On the Beach, so let's stick
with the brand guidelines on this change.