### PR TITLE
Replace the protected with private for accessors

### DIFF
--- a/ruby.rb
+++ b/ruby.rb
@@ -7,7 +7,7 @@ class ExampleClass
   class ThenAnyErrorClass < StandardError;end
 
   attr_reader :stuff, :things
-  protected :stuff, :things
+  private :stuff, :things
 
   def initialize(stuff, things)
     @stuff, @things = stuff, things


### PR DESCRIPTION
The style guide currently uses protected to control visibility of
accessors. In the example I believe the example is intended to
be a private accessor not a protected one. The use of protected is a
hack and is used to prevent a warning the ruby interpreter issues when
it encounters a private accessor.

The core ruby team think accessors should only be used for public
interfaces, but many other rubyists think it is good practice to use
accessors even for private instance variables. OTB is in the latter
camp.

The vast majority of our code does not require protected accessors. To
my knowledge a protected accessor is only needed to implement comparable
objects. Using the hack is tolerable to reduce the warning noise we
might see from code checkers in the future.

However, there is no warning when the accessor is declared as private
afterwards as in:

```
class User
  attr_reader :email
  private :email
end
```

This causes no warnings from MRI (ree -> 2.2). The warning trying to be
avoided occurs only if the accessor is defined below a private keyword
as in:

```
class User
  private
  attr_reader :email
end
```

```
test.rb:3: warning: private attribute?
```

But since our guide has the accessor defined in the former style anyway, I
suggest we don't need to use the protected hack any more.