### PR TITLE
Added Barebones JavaScript Guidelines to Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 * [Ruby](/ruby.rb)
 * [RSpec](/RSpec.md)
 * [(S)CSS](/scss.md)
+* [JavaScript](/javascript.md)
 
 These guidelines provide a summary of coding styles [On the Beach](https://www.onthebeach.co.uk). It is not intended to be exhaustive or absolute.  In general, follow the style of the surrounding code while keeping in mind the following:
 

--- a/javascript.md
+++ b/javascript.md
@@ -1,0 +1,15 @@
+# Coding standards for JavaScript
+
+Welcome to our coding standards for writing JavaScript, jQuery, Backbone and Beyond.
+
+## Coding style
+
+* Use spaces instead of tabs with a 2 space indent
+* Use multiple lines for multiple selectors
+* Use double quotes `"` instead of single quotes `'` around strings where possible
+* Our naming convention is camelCase (https://en.wikipedia.org/wiki/CamelCase) when naming variables and methods
+* Files should be named in Snake_Case to match the Ruby File Structure
+
+## Preference for new files
+
+In general all new JavaScript written for our apps should be written using the BackboneJS (http://backbonejs.org/) library/structure of models, views and collections.


### PR DESCRIPTION
Although it needs fleshing out, I've added a barebones copy of the JavaScript guidelines to the repo and linked it from the readme.md file to make it accessable.

We'll slowly expand on it over time, but at the moment it's very basic and the format is based on the SCSS file.