### PR TITLE
Update RSpec guidelines to place happy path before edge cases

### DIFF
--- a/RSpec.md
+++ b/RSpec.md
@@ -142,6 +142,20 @@ before(:each) { @order = instance_double('Order') }
 let(:order) { instance_double('Order') }
 ```
 
+* Place contexts at the bottom of the `describe` block, with the happy path at
+  the top. This allows the core behaviour to be more visible to people reading
+  the spec for the first time.
+
+```ruby
+describe 'testing the thing' do
+  it 'tests the thing'
+
+  context 'when an edge case ocurrs' do
+    it 'handles it gracefully'
+  end
+end
+```
+
 ## Controllers
 
 * Mock the models and stub their methods. Testing the controller should not


### PR DESCRIPTION
This allows someone reading the spec for the first time to understand
what the single responsibility of the subject under test is, before
reading about the edge cases below.