### PR TITLE
Prefer long-form attr_readers

### DIFF
--- a/ruby.rb
+++ b/ruby.rb
@@ -6,9 +6,6 @@ class ExampleClass
 
   ThenAnyErrorClass = Class.new(StandardError)
 
-  attr_reader :stuff, :things
-  private :stuff, :things
-
   def initialize(stuff, things)
     @stuff, @things = stuff, things
   end
@@ -259,4 +256,16 @@ class ExampleClass
     if_it_can_be_private(make_it_private)
   end
 
+  # Prefer long-form attr_readers over the following hack.
+  #
+  # attr_reader :stuff, :things
+  # private :stuff, :things
+
+  def stuff
+    @stuff
+  end
+
+  def things
+    @things
+  end
 end


### PR DESCRIPTION
Previously, we were using a hack to include private attr_readers, which is not something that we really want to be bragging about. Instead, we should use the long-form private `attr_reader`

![](http://i.giphy.com/3oEjI516pB2OvrlKrm.gif)
