### PR TITLE
Rename scss guidelines to correct name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * [Ruby](/ruby.rb)
 * [RSpec](/RSpec.md)
-* [(S)CSS](/scss.md)
+* [Sass](/scss.md)
 * [JavaScript](/javascript.md)
 
 These guidelines provide a summary of coding styles [On the Beach](https://www.onthebeach.co.uk). It is not intended to be exhaustive or absolute.  In general, follow the style of the surrounding code while keeping in mind the following:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * [Ruby](/ruby.rb)
 * [RSpec](/RSpec.md)
-* [Sass](/scss.md)
+* [Sass](/sass.md)
 * [JavaScript](/javascript.md)
 
 These guidelines provide a summary of coding styles [On the Beach](https://www.onthebeach.co.uk). It is not intended to be exhaustive or absolute.  In general, follow the style of the surrounding code while keeping in mind the following:

--- a/sass.md
+++ b/sass.md
@@ -1,6 +1,10 @@
-# Coding standards for (S)CSS
+# Coding standards for [Sass](http://sass-lang.com)
 
-Welcome to our coding standards for writing (S)CSS.
+Welcome to our coding standards for writing Sass and CSS.
+
+We prefer the `.scss` style of Sass, which is a superset of CSS3, allowing 
+backwards compatability with plain CSS files, meaning any valid CSS file is
+valid SCSS as well.
 
 ## Coding style
 
@@ -37,7 +41,7 @@ e.g:
     }
 
 
-## SCSS Specifics
+## Sass Specifics
 
 Same rules as regular CSS, with a few extensions:
 


### PR DESCRIPTION
This PR renames the SCSS file to Sass, as Sass is the correct name of the language with SCSS being a particular flavour of said language.